### PR TITLE
Add more weight to high-scored posts for defining top contributor

### DIFF
--- a/utopian/app.py
+++ b/utopian/app.py
@@ -597,7 +597,7 @@ def post_statistics_section(categories, contributions):
         rewards = f"{category['utopian_total']:.2f}"
         scores_per_author = category['authors_scores']
         weights_per_author = category['authors_vote_weights']
-        author = f"@{sorted(scores_per_author, key=lambda x: (sum(scores_per_author[x]), sum(weights_per_author[x])), reverse=True)[0]}"
+        author = f"@{sorted(scores_per_author, key=lambda x: (sum(scores_per_author[x]**2), sum(weights_per_author[x])), reverse=True)[0]}"
         category = category["category"]
 
         # Add the row


### PR DESCRIPTION
- contributors with a high score are better candidates for a top contributor